### PR TITLE
DNSSEC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Configuration options for this plugin are in `/etc/foreman-proxy/settings.d/dns_
     :powerdns_mysql_password: ''
     :powerdns_mysql_database: 'powerdns'
 
+### DNSSEC
+
+In case you've enabled DNSSEC (as you should), a rectify-zone is required after every zone change. The pdnssec command is configurable:
+
+    :powerdns_pdnssec: 'pdnssec'
+
+Or a more complex example:
+
+    :powerdns_pdnssec: 'sudo pdnssec --config-name=myconfig'
+
 ## Contributing
 
 Fork and send a Pull Request. Thanks!

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -62,7 +62,7 @@ module Proxy::Dns::Powerdns
       domain_row = domain
       raise Proxy::Dns::Error, "Unable to determine zone. Zone must exist in PowerDNS." unless domain_row
 
-      delete_record(@name, @type)
+      delete_record(domain_row['id'], @name, @type)
     end
 
     private
@@ -98,10 +98,10 @@ module Proxy::Dns::Powerdns
     end
 
     private
-    def delete_record name, type
+    def delete_record domain_id, name, type
       name = mysql_connection.escape(name)
       type = mysql_connection.escape(type)
-      mysql_connection.query("DELETE FROM records WHERE name='#{name}' AND type='#{type}'")
+      mysql_connection.query("DELETE FROM records WHERE domain_id=#{domain_id} AND name='#{name}' AND type='#{type}'")
       # TODO: run rectify-zone
       true
     end

--- a/test/dns_powerdns_record_test.rb
+++ b/test/dns_powerdns_record_test.rb
@@ -25,9 +25,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings)
 
-    instance.expects(:domain_id).returns(1)
-    instance.expects(:dns_find).with('test.example.com').returns(false)
-    instance.expects(:domain_id).returns(1)
+    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:dns_find).with(1, 'test.example.com').returns(false)
     instance.expects(:create_record).with(1, 'test.example.com', 84600, '10.1.1.1', 'A').returns(true)
 
     assert instance.create
@@ -39,8 +38,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings)
 
-    instance.expects(:domain_id).returns(1)
-    instance.expects(:dns_find).with('test.example.com').returns('192.168.1.1')
+    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:dns_find).with(1, 'test.example.com').returns('192.168.1.1')
 
     assert_raise(Proxy::Dns::Collision) { instance.create }
   end
@@ -51,9 +50,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
-    instance.expects(:domain_id).returns(1)
-    instance.expects(:dns_find).with('1.1.1.10.in-addr.arpa').returns(false)
-    instance.expects(:domain_id).returns(1)
+    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:dns_find).with(1, '1.1.1.10.in-addr.arpa').returns(false)
     instance.expects(:create_record).with(1, '1.1.1.10.in-addr.arpa', 84600, 'test.example.com', 'PTR').returns(true)
 
     assert instance.create
@@ -65,8 +63,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
-    instance.expects(:domain_id).returns(1)
-    instance.expects(:dns_find).with('1.1.1.10.in-addr.arpa').returns('test2.example.com')
+    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:dns_find).with(1, '1.1.1.10.in-addr.arpa').returns('test2.example.com')
 
     assert_raise(Proxy::Dns::Collision) { instance.create }
   end
@@ -77,6 +75,7 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings)
 
+    instance.expects(:domain).returns({'id' => 1})
     instance.expects(:delete_record).with('test.example.com', 'A').returns(true)
 
     assert instance.remove
@@ -88,6 +87,7 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
+    instance.expects(:domain).returns({'id' => 1})
     instance.expects(:delete_record).with('1.1.1.10.in-addr.arpa', 'PTR').returns(true)
 
     assert instance.remove

--- a/test/dns_powerdns_record_test.rb
+++ b/test/dns_powerdns_record_test.rb
@@ -75,8 +75,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings)
 
-    instance.expects(:domain).returns({'id' => 1})
-    instance.expects(:delete_record).with('test.example.com', 'A').returns(true)
+    instance.expects(:domain).returns({'id' => 1, 'name' => 'example.com'})
+    instance.expects(:delete_record).with(1, 'test.example.com', 'A').returns(true)
 
     assert instance.remove
   end
@@ -87,8 +87,8 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
-    instance.expects(:domain).returns({'id' => 1})
-    instance.expects(:delete_record).with('1.1.1.10.in-addr.arpa', 'PTR').returns(true)
+    instance.expects(:domain).returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
+    instance.expects(:delete_record).with(1, '1.1.1.10.in-addr.arpa', 'PTR').returns(true)
 
     assert instance.remove
   end

--- a/test/dns_powerdns_record_test.rb
+++ b/test/dns_powerdns_record_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require 'smart_proxy_dns_powerdns/dns_powerdns_main'
 
 class DnsPowerdnsRecordTest < Test::Unit::TestCase
-  # Test that a missing :example_setting throws an error
+  # Test that a missing :powerdns_mysql_hostname throws an error
   def test_initialize_without_settings
     assert_raise(RuntimeError) do
       klass.new(settings.delete_if { |k,v| k == :powerdns_mysql_hostname })

--- a/test/dns_powerdns_record_test.rb
+++ b/test/dns_powerdns_record_test.rb
@@ -50,9 +50,10 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
-    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:domain).returns({'id' => 1, 'name' => 'example.com'})
     instance.expects(:dns_find).with(1, '1.1.1.10.in-addr.arpa').returns(false)
     instance.expects(:create_record).with(1, '1.1.1.10.in-addr.arpa', 84600, 'test.example.com', 'PTR').returns(true)
+    instance.expects(:rectify_zone).with('example.com').returns(true)
 
     assert instance.create
   end
@@ -63,7 +64,7 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance = klass.new(settings.merge(:type => 'PTR'))
 
-    instance.expects(:domain).returns({'id' => 1})
+    instance.expects(:domain).returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
     instance.expects(:dns_find).with(1, '1.1.1.10.in-addr.arpa').returns('test2.example.com')
 
     assert_raise(Proxy::Dns::Collision) { instance.create }
@@ -77,6 +78,7 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance.expects(:domain).returns({'id' => 1, 'name' => 'example.com'})
     instance.expects(:delete_record).with(1, 'test.example.com', 'A').returns(true)
+    instance.expects(:rectify_zone).with('example.com').returns(true)
 
     assert instance.remove
   end
@@ -89,6 +91,7 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
     instance.expects(:domain).returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
     instance.expects(:delete_record).with(1, '1.1.1.10.in-addr.arpa', 'PTR').returns(true)
+    instance.expects(:rectify_zone).with('1.1.10.in-addr.arpa').returns(true)
 
     assert instance.remove
   end


### PR DESCRIPTION
This requires calling rectify-zone after every update. That in turn will need a config option to support the `--config-name` parameter.
