### PR TITLE
Correctly implement create_ptr_record

### DIFF
--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -22,13 +22,12 @@ module Proxy::Dns::Powerdns
       do_create(fqdn, ip, "A")
     end
 
-    def create_ptr_record(fqdn, ip)
-      if found = dns_find(ip)
-        raise Proxy::Dns::Collision, "#{ip} is already in use by #{found}" unless found == fqdn
+    def create_ptr_record(fqdn, value)
+      if found = dns_find(value)
+        raise Proxy::Dns::Collision, "#{value} is already in use by #{found}" unless found == fqdn
       end
 
-      name = IPAddr.new(ip).reverse
-      do_create(name, fqdn, "PTR")
+      do_create(value, fqdn, "PTR")
     end
 
     def do_create(name, value, type)

--- a/test/unit/dns_powerdns_record_test.rb
+++ b/test/unit/dns_powerdns_record_test.rb
@@ -36,21 +36,21 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
   def test_create_ptr
     instance = klass.new
 
-    instance.expects(:dns_find).with('10.1.1.1').returns(false)
+    instance.expects(:dns_find).with('1.1.1.10.in-addr.arpa').returns(false)
     instance.expects(:get_zone).with('1.1.1.10.in-addr.arpa').returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
     instance.expects(:create_record).with(1, '1.1.1.10.in-addr.arpa', 'PTR', 'test.example.com').returns(true)
     instance.expects(:rectify_zone).with('1.1.10.in-addr.arpa').returns(true)
 
-    assert instance.create_ptr_record(fqdn, ip)
+    assert instance.create_ptr_record(fqdn, reverse_ip)
   end
 
   # Test PTR record creation fails if the record exists
   def test_create_ptr_conflict
     instance = klass.new
 
-    instance.expects(:dns_find).with('10.1.1.1').returns('test2.example.com')
+    instance.expects(:dns_find).with('1.1.1.10.in-addr.arpa').returns('test2.example.com')
 
-    assert_raise(Proxy::Dns::Collision) { instance.create_ptr_record(fqdn, ip) }
+    assert_raise(Proxy::Dns::Collision) { instance.create_ptr_record(fqdn, reverse_ip) }
   end
 
   # Test A record removal


### PR DESCRIPTION
create_ptr_record receives the in-addr notation, not an IP. It also
refactors the integration tests to reduce duplication.
