### PR TITLE
Add support for SOA update

### DIFF
--- a/lib/smart_proxy_dns_powerdns/backend/mysql.rb
+++ b/lib/smart_proxy_dns_powerdns/backend/mysql.rb
@@ -31,6 +31,10 @@ module Proxy::Dns::Powerdns::Backend
       domain
     end
 
+    def get_soa_content domain_id
+      connection.query("SELECT content FROM records WHERE domain_id=#{domain_id} AND type='SOA'").map { |e| e['content'] }
+    end
+
     def create_record domain_id, name, type, content
       name = connection.escape(name)
       content = connection.escape(content)

--- a/lib/smart_proxy_dns_powerdns/backend/mysql.rb
+++ b/lib/smart_proxy_dns_powerdns/backend/mysql.rb
@@ -35,6 +35,12 @@ module Proxy::Dns::Powerdns::Backend
       connection.query("SELECT content FROM records WHERE domain_id=#{domain_id} AND type='SOA'").map { |e| e['content'] }
     end
 
+    def update_soa_content domain_id, new_soa
+      s = connection.escape(new_soa)
+      connection.query("UPDATE records SET content='#{s}' WHERE domain_id=#{domain_id} AND type='SOA'")
+      connection.affected_rows == 1
+    end
+
     def create_record domain_id, name, type, content
       name = connection.escape(name)
       content = connection.escape(content)

--- a/lib/smart_proxy_dns_powerdns/backend/postgresql.rb
+++ b/lib/smart_proxy_dns_powerdns/backend/postgresql.rb
@@ -15,6 +15,16 @@ module Proxy::Dns::Powerdns::Backend
       @connection ||= PG.connect(connection_str)
     end
 
+    def get_soa_content domain_id
+      soa = []
+      connection.exec_params("SELECT content FROM records WHERE domain_id=$1::int AND type='SOA'", [domain_id]) do |result|
+        result.each do |row|
+          soa.push(row['content'])
+        end
+      end
+      soa
+    end
+
     def get_zone name
       domain = nil
 

--- a/lib/smart_proxy_dns_powerdns/backend/postgresql.rb
+++ b/lib/smart_proxy_dns_powerdns/backend/postgresql.rb
@@ -25,6 +25,11 @@ module Proxy::Dns::Powerdns::Backend
       soa
     end
 
+    def update_soa_content domain_id, new_soa
+      result = connection.exec_params("UPDATE records SET content=$1 WHERE domain_id=$2::int AND type='SOA'", [new_soa, domain_id])
+      result.cmdtuples == 1
+    end
+
     def get_zone name
       domain = nil
 

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -106,6 +106,45 @@ module Proxy::Dns::Powerdns
       raise Proxy::Dns::Error, "Unable to get SOA record (feature not implemented)"
     end
 
+    def increment_soa_serial(soa, domain_name)
+      # SOA record format (see RFC 1035, 3.3.13)
+      #
+      # MNAME    The <domain-name> of the name server that was the
+      #          original or primary source of data for this zone.
+      #
+      # RNAME    A <domain-name> which specifies the mailbox of the
+      #          person responsible for this zone.
+      #
+      # SERIAL   The unsigned 32 bit version number of the original copy
+      #          of the zone.  Zone transfers preserve this value.  This
+      #          value wraps and should be compared using sequence space
+      #          arithmetic.
+      #
+      # REFRESH  A 32 bit time interval before the zone should be
+      #          refreshed.
+      #
+      # RETRY    A 32 bit time interval that should elapse before a
+      #          failed refresh should be retried.
+      #
+      # EXPIRE   A 32 bit time value that specifies the upper limit on
+      #          the time interval that can elapse before the zone is no
+      #          longer authoritative.
+      #
+      # MINIMUM  The unsigned 32 bit minimum TTL field that should be
+      #          exported with any RR from this zone.
+      field_count = 7
+      elts = soa.split(' ')
+      raise Proxy::Dns::Error, "Invalid SOA record format for domain #{domain_name} (invalid number of fields, expected=#{field_count}, actual=#{elts.size})" unless elts.size == field_count
+      if elts[2].match(/^\d+$/)
+        serial = elts[2].to_i
+      else
+        raise Proxy::Dns::Error, "Invalid SOA record format for domain #{domain_name} (serial '#{elts[2]}' is not a valid integer)"
+      end
+      serial += 1
+      elts[2] = serial.to_s
+      elts.join(' ')
+    end
+
     def create_record(domain_id, name, type, content)
       # TODO: backend specific
       false

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -94,6 +94,18 @@ module Proxy::Dns::Powerdns
       raise Proxy::Dns::Error, "Unable to determine zone for #{name}. Zone must exist in PowerDNS."
     end
 
+    def get_soa(domain_id, domain_name)
+      soa = get_soa_content(domain_id)
+      raise Proxy::Dns::Error, "Missing SOA record for domain #{domain_name}" if soa.empty?
+      raise Proxy::Dns::Error, "Multiple SOA records for domain #{domain_name}" if soa.size != 1
+      soa[0]
+    end
+
+    def get_soa_content(domain_id)
+      # TODO: backend specific
+      raise Proxy::Dns::Error, "Unable to get SOA record (feature not implemented)"
+    end
+
     def create_record(domain_id, name, type, content)
       # TODO: backend specific
       false

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -59,7 +59,7 @@ module Proxy::Dns::Powerdns
 
     def do_create(name, value, type)
       zone = get_zone(name)
-      unless create_record(zone['id'], name, type, value) and rectify_zone(zone['name'])
+      unless create_record(zone['id'], name, type, value) and update_soa(zone['id'], zone['name']) and rectify_zone(zone['name'])
         raise Proxy::Dns::Error.new("Failed to create record #{name} #{type} #{value}")
       end
       true
@@ -83,8 +83,8 @@ module Proxy::Dns::Powerdns
 
     def do_remove(name, type)
       zone = get_zone(name)
-      if delete_record(zone['id'], name, type)
-        raise Proxy::Dns::Error.new("Failed to remove record #{name} #{type}") unless rectify_zone(zone['name'])
+      unless delete_record(zone['id'], name, type) and update_soa(zone['id'], zone['name']) and rectify_zone(zone['name'])
+        raise Proxy::Dns::Error.new("Failed to remove record #{name} #{type}")
       end
       true
     end

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -111,6 +111,12 @@ module Proxy::Dns::Powerdns
       raise Proxy::Dns::Error, "Unable to update SOA record (feature not implemented)"
     end
 
+    def update_soa(domain_id, domain_name)
+      soa = get_soa(domain_id, domain_name)
+      new_soa = increment_soa_serial(soa, domain_name)
+      update_soa_content(domain_id, new_soa)
+    end
+
     def increment_soa_serial(soa, domain_name)
       # SOA record format (see RFC 1035, 3.3.13)
       #

--- a/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
+++ b/lib/smart_proxy_dns_powerdns/dns_powerdns_main.rb
@@ -106,6 +106,11 @@ module Proxy::Dns::Powerdns
       raise Proxy::Dns::Error, "Unable to get SOA record (feature not implemented)"
     end
 
+    def update_soa_content(domain_id, new_soa)
+      # TODO: backend specific
+      raise Proxy::Dns::Error, "Unable to update SOA record (feature not implemented)"
+    end
+
     def increment_soa_serial(soa, domain_name)
       # SOA record format (see RFC 1035, 3.3.13)
       #

--- a/test/unit/dns_powerdns_record_mysql_test.rb
+++ b/test/unit/dns_powerdns_record_mysql_test.rb
@@ -61,4 +61,13 @@ class DnsPowerdnsBackendMysqlTest < Test::Unit::TestCase
     @connection.expects(:query).with(query).returns([{'content' => soa}])
     assert_equal @provider.get_soa_content(domain_id), [soa]
   end
+
+  def test_update_soa_content
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    @connection.expects(:escape).with(soa).returns(soa)
+    @connection.expects(:query).with("UPDATE records SET content='#{soa}' WHERE domain_id=1 AND type='SOA'")
+    @connection.expects(:affected_rows).returns(1)
+    assert @provider.update_soa_content(1, soa)
+  end
+
 end

--- a/test/unit/dns_powerdns_record_mysql_test.rb
+++ b/test/unit/dns_powerdns_record_mysql_test.rb
@@ -54,4 +54,11 @@ class DnsPowerdnsBackendMysqlTest < Test::Unit::TestCase
     assert @provider.delete_record(1, 'test.example.com', 'A')
   end
 
+  def test_get_soa_content
+    domain_id = 1
+    query = "SELECT content FROM records WHERE domain_id=#{domain_id} AND type='SOA'"
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    @connection.expects(:query).with(query).returns([{'content' => soa}])
+    assert_equal @provider.get_soa_content(domain_id), [soa]
+  end
 end

--- a/test/unit/dns_powerdns_record_postgresql_test.rb
+++ b/test/unit/dns_powerdns_record_postgresql_test.rb
@@ -64,4 +64,12 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
 
     assert_true @provider.delete_record(1, 'test.example.com', 'A')
   end
+
+  def test_get_soa_content
+    domain_id = 1
+    query = "SELECT content FROM records WHERE domain_id=$1::int AND type='SOA'"
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    @connection.expects(:exec_params).with(query, [domain_id]).yields([{'content' => soa}])
+    assert_equal @provider.get_soa_content(domain_id), [soa]
+  end
 end

--- a/test/unit/dns_powerdns_record_postgresql_test.rb
+++ b/test/unit/dns_powerdns_record_postgresql_test.rb
@@ -72,4 +72,12 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
     @connection.expects(:exec_params).with(query, [domain_id]).yields([{'content' => soa}])
     assert_equal @provider.get_soa_content(domain_id), [soa]
   end
+
+  def test_update_soa_content
+    query = "UPDATE records SET content=$1 WHERE domain_id=$2::int AND type='SOA'"
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    @connection.expects(:exec_params).with(query, [soa, 1]).returns(mock(:cmdtuples => 1))
+    assert @provider.update_soa_content(1, soa)
+  end
+
 end

--- a/test/unit/dns_powerdns_record_test.rb
+++ b/test/unit/dns_powerdns_record_test.rb
@@ -161,6 +161,20 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
     assert @provider.do_remove('test.example.com', 'A')
   end
 
+  def test_get_soa
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    domain = 'google.com'
+    domain_id = 1
+    @provider.expects(:get_soa_content).with(domain_id).returns([])
+    assert_raise(Proxy::Dns::Error) { @provider.get_soa(domain_id, domain) }
+
+    @provider.expects(:get_soa_content).with(domain_id).returns([soa, soa])
+    assert_raise(Proxy::Dns::Error) { @provider.get_soa(domain_id, domain) }
+
+    @provider.expects(:get_soa_content).with(domain_id).returns([soa])
+    assert_equal @provider.get_soa(domain_id, domain), soa
+  end
+
   private
 
   def fqdn

--- a/test/unit/dns_powerdns_record_test.rb
+++ b/test/unit/dns_powerdns_record_test.rb
@@ -7,6 +7,24 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
     @provider = Proxy::Dns::Powerdns::Record.new('localhost', 86400, 'sudo pdnssec')
   end
 
+  def setup_domain
+    @provider.expects(:get_zone).with(fqdn).returns({'id' => domain_id, 'name' => domain})
+    @provider.expects(:rectify_zone).with(domain).returns(true)
+    @provider.expects(:update_soa).with(domain_id, domain).returns(true)
+  end
+
+  def setup_rev_ipv4_domain
+    @provider.expects(:get_zone).with(reverse_ipv4).returns({'id' => domain_id, 'name' => reverse_ipv4_domain})
+    @provider.expects(:rectify_zone).with(reverse_ipv4_domain).returns(true)
+    @provider.expects(:update_soa).with(domain_id, reverse_ipv4_domain).returns(true)
+  end
+
+  def setup_rev_ipv6_domain
+    @provider.expects(:get_zone).with(reverse_ipv6).returns({'id' => domain_id, 'name' => reverse_ipv6_domain})
+    @provider.expects(:rectify_zone).with(reverse_ipv6_domain).returns(true)
+    @provider.expects(:update_soa).with(domain_id, reverse_ipv6_domain).returns(true)
+  end
+
   def test_initialize
     assert_equal 86400, @provider.ttl
     assert_equal 'sudo pdnssec', @provider.pdnssec
@@ -14,151 +32,140 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
   # Test A record creation
   def test_create_a
-    @provider.expects(:a_record_conflicts).with('test.example.com', '10.1.1.1').returns(-1)
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:create_record).with(1, 'test.example.com', 'A', '10.1.1.1').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
+    setup_domain
+    @provider.expects(:a_record_conflicts).with(fqdn, ipv4).returns(-1)
+    @provider.expects(:create_record).with(1, fqdn, 'A', ipv4).returns(true)
 
     assert @provider.create_a_record(fqdn, ipv4)
   end
 
   # Test A record creation does nothing if the same record exists
   def test_create_a_duplicate
-    @provider.expects(:a_record_conflicts).with('test.example.com', '10.1.1.1').returns(0)
+    @provider.expects(:a_record_conflicts).with(fqdn, ipv4).returns(0)
 
     assert_equal nil, @provider.create_a_record(fqdn, ipv4)
   end
 
   # Test A record creation fails if the record exists
   def test_create_a_conflict
-    @provider.expects(:a_record_conflicts).with('test.example.com', '10.1.1.1').returns(1)
+    @provider.expects(:a_record_conflicts).with(fqdn, ipv4).returns(1)
 
     assert_raise(Proxy::Dns::Collision) { @provider.create_a_record(fqdn, ipv4) }
   end
 
   # Test AAAA record creation
   def test_create_aaaa
-    @provider.expects(:aaaa_record_conflicts).with('test.example.com', '2001:db8:1234:abcd::1').returns(-1)
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:create_record).with(1, 'test.example.com', 'AAAA', '2001:db8:1234:abcd::1').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
+    setup_domain
+    @provider.expects(:aaaa_record_conflicts).with(fqdn, ipv6).returns(-1)
+    @provider.expects(:create_record).with(1, fqdn, 'AAAA', ipv6).returns(true)
 
     assert @provider.create_aaaa_record(fqdn, ipv6)
   end
 
   # Test AAAA record creation does nothing if the same record exists
   def test_create_aaaa_duplicate
-    @provider.expects(:aaaa_record_conflicts).with('test.example.com', '2001:db8:1234:abcd::1').returns(0)
+    @provider.expects(:aaaa_record_conflicts).with(fqdn, ipv6).returns(0)
 
     assert_equal nil, @provider.create_aaaa_record(fqdn, ipv6)
   end
 
   # Test AAAA record creation fails if the record exists
   def test_create_aaaa_conflict
-    @provider.expects(:aaaa_record_conflicts).with('test.example.com', '2001:db8:1234:abcd::1').returns(1)
+    @provider.expects(:aaaa_record_conflicts).with(fqdn, ipv6).returns(1)
 
     assert_raise(Proxy::Dns::Collision) { @provider.create_aaaa_record(fqdn, ipv6) }
   end
 
   # Test CNAME record creation
   def test_create_cname
-    @provider.expects(:cname_record_conflicts).with('test.example.com', 'something.example.com').returns(-1)
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:create_record).with(1, 'test.example.com', 'CNAME', 'something.example.com').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
+    setup_domain
+    @provider.expects(:cname_record_conflicts).with(fqdn, cname).returns(-1)
+    @provider.expects(:create_record).with(1, fqdn, 'CNAME', cname).returns(true)
 
-    assert @provider.create_cname_record(fqdn, 'something.example.com')
+    assert @provider.create_cname_record(fqdn, cname)
   end
 
   # Test CNAME record creation does nothing if the same record exists
   def test_create_cname_duplicate
-    @provider.expects(:cname_record_conflicts).with('test.example.com', 'something.example.com').returns(0)
+    @provider.expects(:cname_record_conflicts).with(fqdn, cname).returns(0)
 
-    assert_equal nil, @provider.create_cname_record(fqdn, 'something.example.com')
+    assert_equal nil, @provider.create_cname_record(fqdn, cname)
   end
 
   # Test CNAME record creation fails if the record exists
   def test_create_cname_conflict
-    @provider.expects(:cname_record_conflicts).with('test.example.com', 'something.example.com').returns(1)
+    @provider.expects(:cname_record_conflicts).with(fqdn, cname).returns(1)
 
-    assert_raise(Proxy::Dns::Collision) { @provider.create_cname_record(fqdn, 'something.example.com') }
+    assert_raise(Proxy::Dns::Collision) { @provider.create_cname_record(fqdn, cname) }
   end
 
   # Test PTR record creation
   def test_create_ptr
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '10.1.1.1').returns(-1)
-    @provider.expects(:get_zone).with('1.1.1.10.in-addr.arpa').returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
-    @provider.expects(:create_record).with(1, '1.1.1.10.in-addr.arpa', 'PTR', 'test.example.com').returns(true)
-    @provider.expects(:rectify_zone).with('1.1.10.in-addr.arpa').returns(true)
+    setup_rev_ipv4_domain
+    @provider.expects(:ptr_record_conflicts).with(fqdn, ipv4).returns(-1)
+    @provider.expects(:create_record).with(1, reverse_ipv4, 'PTR', fqdn).returns(true)
 
     assert @provider.create_ptr_record(fqdn, reverse_ipv4)
   end
 
   # Test PTR record creation does nothing if the same record exists
   def test_create_ptr_duplicate
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '10.1.1.1').returns(0)
+    @provider.expects(:ptr_record_conflicts).with(fqdn, ipv4).returns(0)
 
     assert_equal nil, @provider.create_ptr_record(fqdn, reverse_ipv4)
   end
 
   # Test PTR record creation fails if the record exists
   def test_create_ptr_conflict
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '10.1.1.1').returns(1)
+    @provider.expects(:ptr_record_conflicts).with(fqdn, ipv4).returns(1)
 
     assert_raise(Proxy::Dns::Collision) { @provider.create_ptr_record(fqdn, reverse_ipv4) }
   end
 
   # Test PTR record creation
   def test_create_ptr_ipv6
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '2001:0db8:1234:abcd:0000:0000:0000:0001').returns(-1)
-    @provider.expects(:get_zone).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa').returns({'id' => 1, 'name' => 'd.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa'})
-    @provider.expects(:create_record).with(1, '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa', 'PTR', 'test.example.com').returns(true)
-    @provider.expects(:rectify_zone).with('d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa').returns(true)
+    setup_rev_ipv6_domain
+    @provider.expects(:ptr_record_conflicts).with(fqdn, '2001:0db8:1234:abcd:0000:0000:0000:0001').returns(-1)
+    @provider.expects(:create_record).with(1, reverse_ipv6, 'PTR', fqdn).returns(true)
 
     assert @provider.create_ptr_record(fqdn, reverse_ipv6)
   end
 
   # Test A record removal
   def test_remove_a
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:delete_record).with(1, 'test.example.com', 'A').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
-
+    setup_domain
+    @provider.expects(:delete_record).with(1, fqdn, 'A').returns(true)
     assert @provider.remove_a_record(fqdn)
   end
 
   # Test PTR record removal
   def test_remove_ptr_ipv4
-    @provider.expects(:get_zone).with('1.1.1.10.in-addr.arpa').returns({'id' => 1, 'name' => '1.1.10.in-addr.arpa'})
-    @provider.expects(:delete_record).with(1, '1.1.1.10.in-addr.arpa', 'PTR').returns(true)
-    @provider.expects(:rectify_zone).with('1.1.10.in-addr.arpa').returns(true)
+    setup_rev_ipv4_domain
+    @provider.expects(:delete_record).with(1, reverse_ipv4, 'PTR').returns(true)
 
     assert @provider.remove_ptr_record(reverse_ipv4)
   end
 
   # Test PTR record removal
   def test_remove_ptr_ipv6
-    @provider.expects(:get_zone).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa').returns({'id' => 1, 'name' => 'd.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa'})
-    @provider.expects(:delete_record).with(1, '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa', 'PTR').returns(true)
-    @provider.expects(:rectify_zone).with('d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa').returns(true)
+    setup_rev_ipv6_domain
+    @provider.expects(:delete_record).with(1, reverse_ipv6, 'PTR').returns(true)
 
     assert @provider.remove_ptr_record(reverse_ipv6)
   end
 
   def test_do_create
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:create_record).with(1, 'test.example.com', 'A', '10.1.1.1').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
+    setup_domain
+    @provider.expects(:create_record).with(domain_id, fqdn, 'A', ipv4).returns(true)
 
-    assert @provider.do_create('test.example.com', '10.1.1.1', 'A')
+    assert @provider.do_create(fqdn, ipv4, 'A')
   end
 
   def test_do_remove
-    @provider.expects(:get_zone).with('test.example.com').returns({'id' => 1, 'name' => 'example.com'})
-    @provider.expects(:delete_record).with(1, 'test.example.com', 'A').returns(true)
-    @provider.expects(:rectify_zone).with('example.com').returns(true)
+    setup_domain
+    @provider.expects(:delete_record).with(1, fqdn, 'A').returns(true)
 
-    assert @provider.do_remove('test.example.com', 'A')
+    assert @provider.do_remove(fqdn, 'A')
   end
 
   def test_get_soa
@@ -199,8 +206,20 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
 
   private
 
+  def domain
+    'example.com'
+  end
+
+  def domain_id
+    1
+  end
+
   def fqdn
-    'test.example.com'
+    "test.#{domain}"
+  end
+
+  def cname
+    "alias.#{domain}"
   end
 
   def ipv4
@@ -211,11 +230,19 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
     '1.1.1.10.in-addr.arpa'
   end
 
+  def reverse_ipv4_domain
+    '1.1.10.in-addr.arpa'
+  end
+
   def ipv6
     '2001:db8:1234:abcd::1'
   end
 
   def reverse_ipv6
     '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa'
+  end
+
+  def reverse_ipv6_domain
+    'd.c.b.a.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa'
   end
 end

--- a/test/unit/dns_powerdns_record_test.rb
+++ b/test/unit/dns_powerdns_record_test.rb
@@ -185,6 +185,18 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
     assert_equal @provider.increment_soa_serial("#{prefix} #{serial} #{suffix}", 'google.com'), "#{prefix} #{serial+1} #{suffix}"
   end
 
+  def test_update_soa
+    soa = 'ns1.google.com. dns-admin.google.com. 144210844 900 900 1800 60'
+    new_soa = 'ns1.google.com. dns-admin.google.com. 144210845 900 900 1800 60'
+    domain = 'google.com'
+    domain_id = 1
+    @provider.expects(:get_soa).with(domain_id, domain).returns(soa)
+    @provider.expects(:increment_soa_serial).with(soa, domain).returns(new_soa)
+    @provider.expects(:update_soa_content).with(domain_id, new_soa).returns(true)
+
+    assert @provider.update_soa(domain_id, domain)
+  end
+
   private
 
   def fqdn

--- a/test/unit/dns_powerdns_record_test.rb
+++ b/test/unit/dns_powerdns_record_test.rb
@@ -175,6 +175,16 @@ class DnsPowerdnsRecordTest < Test::Unit::TestCase
     assert_equal @provider.get_soa(domain_id, domain), soa
   end
 
+  def test_increment_soa_serial
+    prefix = 'ns2.google.com. dns-admin.google.com.'
+    serial = 144200724
+    suffix = '900 900 1800 60'
+    assert_raise(Proxy::Dns::Error) { @provider.increment_soa_serial(prefix, 'google.com') }
+    assert_raise(Proxy::Dns::Error) { @provider.increment_soa_serial("#{prefix} invalid_serial #{suffix}", 'google.com') }
+
+    assert_equal @provider.increment_soa_serial("#{prefix} #{serial} #{suffix}", 'google.com'), "#{prefix} #{serial+1} #{suffix}"
+  end
+
   private
 
   def fqdn


### PR DESCRIPTION
Simple implementation to update the SOA record when adding or deleting records in MySQL or PostgreSQL (see #22)
**Support for REST backend has not been implemented**

This implementation is far from ideal:
* lacks transaction support but it is not really a big deal: if SOA update does not work, a message will be triggered and user can update the field manually. Record (A/AAAA/PTR/CNAME) will still be present in the table though.
* no protection against concurrent requests: SOA is read, then updated. There is nothing that prevents two functions reading the same SOA, and finally setting `serial+1` as the final serial (instead of `serial+1`, the `serial+2`)

Any ideas are welcome.