### PR TITLE
Update `change_date` field of records for MySQL and PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ Or a more complex example:
 
 Note that PowerDNS 4.x now uses `pdnsutil` rather than `pdnssec`.
 
+### SOA autoserial with MySQL and PostgreSQL
+
+PowerDNS (>= 3.3) provides a feature called `autoserial` that takes care of managing the serial of `SOA` records.
+
+There are many options available regarding how PowerDNS generates the serial and details can be found looking for the `SOA-EDIT` option in PowerDNS.
+
+One option is to let the PowerDNS backend determine the `SOA` serial using the biggest `change_date` of the records associated with the DNS domain.
+`smart_proxy_dns_powerdns` uses this approach and updates the `change_date` field of changed records, setting them to the current timestamp of the database server, represented as **the number of seconds since EPOCH**.
+
+* when a new record is created, its `change_date` is set accordingly
+* when a record is deleted, the `change_date` of the `SOA` record for the domain is updated
+
 ## Contributing
 
 Fork and send a Pull Request. Thanks!

--- a/lib/smart_proxy_dns_powerdns/backend/mysql.rb
+++ b/lib/smart_proxy_dns_powerdns/backend/mysql.rb
@@ -35,7 +35,7 @@ module Proxy::Dns::Powerdns::Backend
       name = connection.escape(name)
       content = connection.escape(content)
       type = connection.escape(type)
-      connection.query("INSERT INTO records (domain_id, name, ttl, content, type) VALUES (#{domain_id}, '#{name}', #{ttl.to_i}, '#{content}', '#{type}')")
+      connection.query("INSERT INTO records (domain_id, name, ttl, content, type, change_date) VALUES (#{domain_id}, '#{name}', #{ttl.to_i}, '#{content}', '#{type}', UNIX_TIMESTAMP())")
       connection.affected_rows == 1
     end
 
@@ -43,7 +43,12 @@ module Proxy::Dns::Powerdns::Backend
       name = connection.escape(name)
       type = connection.escape(type)
       connection.query("DELETE FROM records WHERE domain_id=#{domain_id} AND name='#{name}' AND type='#{type}'")
-      connection.affected_rows >= 1
+      ret = connection.affected_rows >= 1
+      if ret
+        connection.query("UPDATE records SET change_date=UNIX_TIMESTAMP() WHERE domain_id=#{domain_id} AND type='SOA'")
+        ret = connection.affected_rows == 1
+      end
+      ret
     end
   end
 end

--- a/test/unit/dns_powerdns_record_mysql_test.rb
+++ b/test/unit/dns_powerdns_record_mysql_test.rb
@@ -46,22 +46,69 @@ class DnsPowerdnsBackendMysqlTest < Test::Unit::TestCase
   end
 
   def test_delete_record
-    @connection.expects(:escape).with('test.example.com').returns('test.example.com')
-    @connection.expects(:escape).with('A').returns('A')
-    @connection.expects(:query).with("DELETE FROM records WHERE domain_id=1 AND name='test.example.com' AND type='A'")
-    @connection.expects(:affected_rows).returns(1)
-    @connection.expects(:query).with("UPDATE records SET change_date=UNIX_TIMESTAMP() WHERE domain_id=1 AND type='SOA'")
-    @connection.expects(:affected_rows).returns(1)
-    assert @provider.delete_record(1, 'test.example.com', 'A')
+    mock_escapes(fqdn, 'A')
+    @connection.expects(:query).with(query_delete)
+    @connection.expects(:query).with(query_update_soa)
+    @connection.expects(:affected_rows).twice.returns(1)
+    assert @provider.delete_record(domain_id, fqdn, 'A')
   end
 
   def test_delete_no_record
-    @connection.expects(:escape).with('test.example.com').returns('test.example.com')
-    @connection.expects(:escape).with('A').returns('A')
-    @connection.expects(:query).with("DELETE FROM records WHERE domain_id=1 AND name='test.example.com' AND type='A'")
+    mock_escapes(fqdn, 'A')
+    @connection.expects(:query).with(query_delete)
     @connection.expects(:affected_rows).returns(0)
 
-    assert_false @provider.delete_record(1, 'test.example.com', 'A')
+    assert_false @provider.delete_record(domain_id, fqdn, 'A')
+  end
+
+  def test_delete_record_no_soa
+    mock_escapes(fqdn, 'A')
+    @connection.expects(:query).with(query_delete)
+    @connection.expects(:query).with(query_update_soa)
+    @connection.expects(:affected_rows).twice.returns(1, 0)
+    logger = mock()
+    logger.expects(:info)
+    @provider.stubs(:logger).returns(logger)
+
+    assert @provider.delete_record(domain_id, fqdn, 'A')
+  end
+
+  def test_delete_record_multiple_soa
+    mock_escapes(fqdn, 'A')
+    @connection.expects(:query).with(query_delete)
+    @connection.expects(:query).with(query_update_soa)
+    @connection.expects(:affected_rows).twice.returns(1, 2)
+    logger = mock()
+    logger.expects(:warning)
+    @provider.stubs(:logger).returns(logger)
+
+    assert @provider.delete_record(domain_id, fqdn, 'A')
+  end
+
+  private
+
+  def mock_escapes(*elts)
+    elts.each { |e| @connection.expects(:escape).with(e).returns(e) }
+  end
+
+  def domain
+    'example.com'
+  end
+
+  def fqdn
+    "test.#{domain}"
+  end
+
+  def domain_id
+    1
+  end
+
+  def query_delete(type='A')
+    "DELETE FROM records WHERE domain_id=#{domain_id} AND name='#{fqdn}' AND type='#{type}'"
+  end
+
+  def query_update_soa
+    "UPDATE records SET change_date=UNIX_TIMESTAMP() WHERE domain_id=#{domain_id} AND type='SOA'"
   end
 
 end

--- a/test/unit/dns_powerdns_record_postgresql_test.rb
+++ b/test/unit/dns_powerdns_record_postgresql_test.rb
@@ -35,7 +35,7 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
 
   def test_create_record
     @connection.expects(:exec_params).
-      with("INSERT INTO records (domain_id, name, ttl, content, type) VALUES ($1::int, $2, $3::int, $4, $5)", [1, 'test.example.com', 86400, '10.1.1.1', 'A']).
+      with("INSERT INTO records (domain_id, name, ttl, content, type, change_date) VALUES ($1::int, $2, $3::int, $4, $5, extract(epoch from now()))", [1, 'test.example.com', 86400, '10.1.1.1', 'A']).
       returns(mock(:cmdtuples => 1))
 
     assert_true @provider.create_record(1, 'test.example.com', 'A', '10.1.1.1')
@@ -53,6 +53,9 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
     @connection.expects(:exec_params).
       with("DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3", [1, 'test.example.com', 'A']).
       returns(mock(:cmdtuples => 1))
+    @connection.expects(:exec_params).
+      with("UPDATE records SET change_date=extract(epoch from now()) WHERE domain_id=$1::int AND type='SOA'", [1]).
+      returns(mock(:cmdtuples => 1))
 
     assert_true @provider.delete_record(1, 'test.example.com', 'A')
   end
@@ -61,6 +64,9 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
     @connection.expects(:exec_params).
       with("DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3", [1, 'test.example.com', 'A']).
       returns(mock(:cmdtuples => 2))
+    @connection.expects(:exec_params).
+      with("UPDATE records SET change_date=extract(epoch from now()) WHERE domain_id=$1::int AND type='SOA'", [1]).
+      returns(mock(:cmdtuples => 1))
 
     assert_true @provider.delete_record(1, 'test.example.com', 'A')
   end

--- a/test/unit/dns_powerdns_record_postgresql_test.rb
+++ b/test/unit/dns_powerdns_record_postgresql_test.rb
@@ -42,32 +42,84 @@ class DnsPowerdnsBackendPostgresqlTest < Test::Unit::TestCase
   end
 
   def test_delete_record_no_records
-    @connection.expects(:exec_params).
-      with("DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3", [1, 'test.example.com', 'A']).
-      returns(mock(:cmdtuples => 0))
-
-    assert_false @provider.delete_record(1, 'test.example.com', 'A')
+    mock_delete_tuples(0)
+    assert_false run_delete_record
   end
 
   def test_delete_record_single_record
-    @connection.expects(:exec_params).
-      with("DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3", [1, 'test.example.com', 'A']).
-      returns(mock(:cmdtuples => 1))
-    @connection.expects(:exec_params).
-      with("UPDATE records SET change_date=extract(epoch from now()) WHERE domain_id=$1::int AND type='SOA'", [1]).
-      returns(mock(:cmdtuples => 1))
+    mock_delete_tuples(1)
+    mock_update_soa_tuples(1)
 
-    assert_true @provider.delete_record(1, 'test.example.com', 'A')
+    assert_true run_delete_record
   end
 
   def test_delete_record_multiple_records
-    @connection.expects(:exec_params).
-      with("DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3", [1, 'test.example.com', 'A']).
-      returns(mock(:cmdtuples => 2))
-    @connection.expects(:exec_params).
-      with("UPDATE records SET change_date=extract(epoch from now()) WHERE domain_id=$1::int AND type='SOA'", [1]).
-      returns(mock(:cmdtuples => 1))
+    mock_delete_tuples(2)
+    mock_update_soa_tuples(1)
 
-    assert_true @provider.delete_record(1, 'test.example.com', 'A')
+    assert_true run_delete_record
   end
+
+  def test_delete_record_no_soa
+    mock_delete_tuples(1)
+    mock_update_soa_tuples(0)
+    logger = mock()
+    logger.expects(:info)
+    @provider.stubs(:logger).returns(logger)
+
+    assert_true run_delete_record
+  end
+
+  def test_delete_record_multiple_soa
+    mock_delete_tuples(1)
+    mock_update_soa_tuples(2)
+    logger = mock()
+    logger.expects(:warning)
+    @provider.stubs(:logger).returns(logger)
+
+    assert_true run_delete_record
+  end
+
+  private
+
+  def mock_delete_tuples(cmdtuples)
+    @connection.expects(:exec_params).
+      with(query_delete, [domain_id, fqdn, record_type]).
+      returns(mock(:cmdtuples => cmdtuples))
+  end
+
+  def mock_update_soa_tuples(cmdtuples)
+    @connection.expects(:exec_params).
+      with(query_update_soa, [domain_id]).
+      returns(mock(:cmdtuples => cmdtuples))
+  end
+
+  def run_delete_record
+    @provider.delete_record(domain_id, fqdn, record_type)
+  end
+
+  def domain
+    'example.com'
+  end
+
+  def fqdn
+    "test.#{domain}"
+  end
+
+  def domain_id
+    1
+  end
+
+  def record_type
+    'A'
+  end
+
+  def query_delete
+    "DELETE FROM records WHERE domain_id=$1::int AND name=$2 AND type=$3"
+  end
+
+  def query_update_soa
+    "UPDATE records SET change_date=extract(epoch from now()) WHERE domain_id=$1::int AND type='SOA'"
+  end
+
 end


### PR DESCRIPTION
The `change_date` field must be updated in order for PowerDNS to be able to generate or regenerate
the SOA serial of the modified zone.

* On create, new record gets its `change_date` field set to the current timestamp (ie. epoch).
* On delete, update the `change_date` field for the SOA record of the associated domain.

Related to issue #22